### PR TITLE
Gemm

### DIFF
--- a/scid/ops/common.d
+++ b/scid/ops/common.d
@@ -199,7 +199,7 @@ mixin template GeneralMatrixScalingAndAddition() {
 				blas.copy( ldb, b, 1, dest.data, dest.stride );
 		}
 	}
-	/*
+	
 	void matrixProduct( Transpose transA = Transpose.no, Transpose transB = Transpose.no, A, B )
 			( ElementType alpha, auto ref A a, auto ref B b, ElementType beta ) if( isGeneralMatrixStorage!A && isGeneralMatrixStorage!B ) {
 		import scid.blas;
@@ -230,12 +230,12 @@ mixin template GeneralMatrixScalingAndAddition() {
 				else
 					this.resize( m, n, null );
 				assert( a.cdata && b.cdata );
-				blas.gemm( chTransA, chTransB, m, n, ak, alpha, a.cdata, a.leading, b.cdata, b.leading, beta, this.data, this.leading );	
+				blas.gemm!( chTransA, chTransB )( m, n, ak, alpha, a.cdata, a.leading, b.cdata, b.leading, beta, this.data, this.leading );	
 			}
 		} else {
 			assert( false );
 		}
-	}*/
+	}
 }
 
 /** Compute the dot product of a row and a column of possibly transposed matrices. */


### PR DESCRIPTION
Re-enable the BLAS-calling matrix multiply, which was commented out, and fix calling of blas.gemm so it actually gets called.  If there was a good reason why this was commented out, etc. that I'm not aware of, please just say so and close the pull request.
