### PR TITLE
Cholesky, deciding on conventions for LAPACK wrappers.

### DIFF
--- a/scid/linalg.d
+++ b/scid/linalg.d
@@ -1,0 +1,150 @@
+/**
+This module contains linear algebra functions beyond basic expressions,
+such as matrix factorizations.  This module also contains destructive
+versions of some functions.  These are named someFunctionDestructive,
+and use their input arguments as scratch space.
+*/
+module scid.linalg;
+
+import std.string;
+
+import scid.internal.regionallocator;
+import scid.lapack;
+import scid.matrix;
+import scid.common.traits;
+
+/**
+Performs Cholesky decomposition of a Hermitian, positive definite matrix.  
+Assuming the input matrix is named A, Cholesky decomposition has the 
+following forms:
+
+mat = L * L.t if L is a lower triangular matrix.
+mat = U.t * U if U is an upper triangular matrix.
+
+mat must be symmetric, but it may be stored redundantly using general matrix
+storage.  If general matrix storage is used, symmetry is not checked in
+the interest of efficiency.
+
+Returns:  
+
+The matrix U that would be multiplied by its conjugate transpose as
+shown above to form mat.
+*/
+auto cholesky( M )( M mat )
+if( isMatrix!M ) {  
+    alias M.ElementType E;
+    auto ret = TriangularMatrix!E( mat.rows, null );
+    choleskyImpl( mat, ret );
+    return ret;
+}
+
+/// Ditto
+auto cholesky( M, Allocator )( M mat, Allocator alloc ) 
+if( isMatrix!M && isAllocator!Allocator ) {
+    alias M.ElementType E;
+    alias TriangularMatrix!(E).Temporary Temp;
+    auto ret = Temp( mat.rows, alloc );
+    choleskyImpl( mat, ret );
+    return ret;
+}
+
+     
+private void choleskyImpl( M1, M2 )( ref M1 mat, ref M2 ret ) {
+    alias M1.ElementType E;
+    
+    auto alloc = newRegionAllocator();
+    auto temp = ExternalMatrixView!E( mat.rows, mat.rows, alloc );
+    
+    // Copy only the upper triangle of mat
+    foreach( col; 0..mat.columns ) {
+        foreach( row; 0..col + 1 ) {
+            temp[ row, col ] = mat[ row, col ];
+        }
+    }        
+    
+    int info;    
+    lapack.potrf!( 'U' )
+        ( temp.length, temp.data, temp.rows, info );
+    
+    // TODO:  Establish a consistent standard for error handling.
+    // For now, just return a matrix of NaNs.
+    if( info > 0 ) {
+        ret.data[ 0..ret.length ] = E.init;
+        return;
+    }
+    
+    // Copy only the upper triangle of temp to ret.
+    foreach( col; 0..temp.columns ) {
+        foreach( row; 0..col + 1 ) {
+            ret[ row, col ] = temp[ row, col ];
+        }
+    } 
+        
+    return;
+}
+    
+/**
+Computes the Cholesky decomposition of a matrix without any copying.
+Upon exiting, the upper triangle of mat will contain the result and the lower
+triangle will contain zeros.  mat must be symmetric (this is not checked) but
+must use general matrix storage even though it must be symmetric, since the 
+lower triangle is used as scratch space.
+*/
+void choleskyDestructive( M )( ref M mat )
+if( isMatrix!M && isGeneralMatrixStorage!( M.Storage, M.ElementType ) ) {
+    assert( mat.rows == mat.columns, format(
+        "mat must be symmetric for choleskyDestructive.  Got a matrix with " ~
+        "%s rows, %s columns.",  mat.rows, mat.columns
+    ));
+
+    int info;    
+    lapack.potrf!( 'U' )
+        ( mat.length, mat.data, mat.rows, info );
+        
+    // TODO:  Establish a consistent standard for error handling.
+    // For now, just return a matrix of NaNs.
+    if( info > 0 ) {
+        mat.data[ 0..mat.length ] = M.ElementType.init;
+        return;
+    }
+    
+    foreach( col; 0..mat.columns ) {
+        foreach( row; col + 1..mat.columns ) {
+            mat[ row, col ] = 0;
+        }
+    }
+}
+    
+unittest {
+    import std.stdio;
+    import std.math;
+    
+    // Easy way to get a positive definite matrix to test with:
+    auto mat = SymmetricMatrix!double( [
+        [14.0, 20, 31], 
+        [20.0, 62, 79], 
+        [31.0, 79, 122]
+    ] );
+    
+    auto ch = cholesky( mat );
+    alias approxEqual ae;  // Save typing.
+    assert( ae( ch[ 0, 0 ], 3.74166 ) );
+    assert( ae( ch[ 0, 1 ], 5.34522 ) );
+    assert( ae( ch[ 0, 2 ], 8.28510 ) );
+    assert( ae( ch[ 1, 1 ], 5.78174 ) );
+    assert( ae( ch[ 1, 2 ], 6.00412 ) );
+    assert( ae( ch[ 2, 2 ], 4.16025 ) );
+    
+    auto alloc = newRegionAllocator();
+    auto ch2 = cholesky( mat, alloc );
+    foreach( row; 0..3 ) foreach( col; 0..3 ) {
+        assert( ch[ row, col ] == ch2[ row, col ]);
+    }
+    
+    Matrix!double gen;
+    gen[] = mat;
+    choleskyDestructive(gen);
+    foreach( row; 0..3 ) foreach( col; 0..3 ) {
+        assert( ch[ row, col ] == gen[ row, col ]);
+    }
+}

--- a/scid/linalg.d
+++ b/scid/linalg.d
@@ -21,33 +21,58 @@ following forms:
 mat = L * L.t if L is a lower triangular matrix.
 mat = U.t * U if U is an upper triangular matrix.
 
-mat must be symmetric, but it may be stored redundantly using general matrix
-storage.  If general matrix storage is used, symmetry is not checked in
-the interest of efficiency.
+Cholesky decomposition solves for L or U.
+
+mat may be a symmetric, triangular or general matrix, even though strictly
+speaking Cholesky factorization is only defined for symmetric/Hermitian
+matrices.  The triangle used to compute the Cholesky
+decomposition is the upper if tri == MatrixTriangle.Upper or the lower
+if tri == MatrixTriangle.Lower.  The other triangle is ignored.
 
 Returns:  
 
 The matrix U that would be multiplied by its conjugate transpose as
-shown above to form mat.
+shown above to form mat, or the matrix L that would be multiplied by
+its conjugate transpose to form mat, depending on the parameter tri.
+
+Example:
+---
+auto mat = Matrix!double([
+    [3, 1, 4],
+    [5, 9, 2],
+    [6, 5, 3]]
+);
+
+auto result = cholesky!(MatrixTriangle.Upper)(mat);
+
+// The lower triangle of mat is ignored.  The above is equivalent to:
+auto mat2 = SymmetricMatrix!double([
+    [3, 1, 4],
+    [1, 9, 2],
+    [4, 2, 3]]
+);
+
+auto result2 = cholesky!(MatrixTriangle.Upper)(mat2);
+---
 */
-auto cholesky( M )( M mat )
+auto cholesky( MatrixTriangle tri = MatrixTriangle.Upper, M )( M mat )
 if( isMatrix!M ) {  
     alias M.ElementType E;
-    auto ret = TriangularMatrix!E( mat.rows, null );
+    auto ret = TriangularMatrix!( E, tri )( mat.rows, null );
     choleskyImpl( mat, ret );
     return ret;
 }
 
 /// Ditto
-auto cholesky( M, Allocator )( M mat, Allocator alloc ) 
+auto cholesky( MatrixTriangle tri = MatrixTriangle.Upper, M, Allocator )
+( M mat, Allocator alloc ) 
 if( isMatrix!M && isAllocator!Allocator ) {
     alias M.ElementType E;
-    alias TriangularMatrix!(E).Temporary Temp;
+    alias TriangularMatrix!( E, tri ).Temporary Temp;
     auto ret = Temp( mat.rows, alloc );
     choleskyImpl( mat, ret );
     return ret;
 }
-
      
 private void choleskyImpl( M1, M2 )( ref M1 mat, ref M2 ret ) {
     alias M1.ElementType E;
@@ -55,15 +80,32 @@ private void choleskyImpl( M1, M2 )( ref M1 mat, ref M2 ret ) {
     auto alloc = newRegionAllocator();
     auto temp = ExternalMatrixView!E( mat.rows, mat.rows, alloc );
     
-    // Copy only the upper triangle of mat
-    foreach( col; 0..mat.columns ) {
-        foreach( row; 0..col + 1 ) {
-            temp[ row, col ] = mat[ row, col ];
-        }
-    }        
+    static void copyUpperTriangle( M1, M2 )( ref M1 src, ref M2 dest ) {
+        foreach( col; 0..src.columns ) {
+            foreach( row; 0..col + 1 ) {
+                dest[ row, col ] = src[ row, col ];
+            }
+        }        
+    }
+    
+    static void copyLowerTriangle( M1, M2 )( ref M1 src, ref M2 dest ) {
+        foreach( col; 0..src.columns ) {
+            foreach( row; col..src.columns ) {
+                dest[ row, col ] = src[ row, col ];
+            }
+        }        
+    }
+    
+    static if( ret.triangle == MatrixTriangle.Upper ) {
+        copyUpperTriangle( mat, temp );
+        enum uplo = 'U';
+    } else {
+        copyLowerTriangle( mat, temp );
+        enum uplo = 'L';
+    }
     
     int info;    
-    lapack.potrf!( 'U' )
+    lapack.potrf!( uplo )
         ( temp.length, temp.data, temp.rows, info );
     
     // TODO:  Establish a consistent standard for error handling.
@@ -73,24 +115,27 @@ private void choleskyImpl( M1, M2 )( ref M1 mat, ref M2 ret ) {
         return;
     }
     
-    // Copy only the upper triangle of temp to ret.
-    foreach( col; 0..temp.columns ) {
-        foreach( row; 0..col + 1 ) {
-            ret[ row, col ] = temp[ row, col ];
-        }
-    } 
+    static if( uplo == 'U' ) {
+        copyUpperTriangle( temp, ret );
+    } else {
+        copyLowerTriangle( temp, ret );
+    }
         
     return;
 }
     
 /**
 Computes the Cholesky decomposition of a matrix without any copying.
-Upon exiting, the upper triangle of mat will contain the result and the lower
-triangle will contain zeros.  mat must be symmetric (this is not checked) but
-must use general matrix storage even though it must be symmetric, since the 
-lower triangle is used as scratch space.
+Upon exiting, the upper or lower triangle of mat (depending on the value
+of tri) will contain the result and the other triangle will contain zeros.  
+mat is interpreted as a symmetric matrix and the upper or lower triangle
+(depending on the value of tri) is used to compute the Cholesky decomposition
+and the other triangle is ignored, similarly to cholesky().  However, mat must 
+use general matrix storage, since one of the two triangles is used as scratch 
+space.
 */
-void choleskyDestructive( M )( ref M mat )
+void choleskyDestructive
+( MatrixTriangle tri = MatrixTriangle.Upper, M )( ref M mat )
 if( isMatrix!M && isGeneralMatrixStorage!( M.Storage, M.ElementType ) ) {
     assert( mat.rows == mat.columns, format(
         "mat must be symmetric for choleskyDestructive.  Got a matrix with " ~
@@ -98,7 +143,7 @@ if( isMatrix!M && isGeneralMatrixStorage!( M.Storage, M.ElementType ) ) {
     ));
 
     int info;    
-    lapack.potrf!( 'U' )
+    lapack.potrf!( ( tri == MatrixTriangle.Upper ) ? 'U' : 'L' )
         ( mat.length, mat.data, mat.leading, info );
         
     // TODO:  Establish a consistent standard for error handling.
@@ -109,7 +154,16 @@ if( isMatrix!M && isGeneralMatrixStorage!( M.Storage, M.ElementType ) ) {
     }
     
     foreach( col; 0..mat.columns ) {
-        foreach( row; col + 1..mat.columns ) {
+
+        static if( tri == MatrixTriangle.Upper ) {
+            immutable start = col + 1;
+            immutable end = mat.columns;
+        } else {
+            immutable start = 0;
+            immutable end = col;
+        }
+        
+        foreach( row; start..end ) {
             mat[ row, col ] = 0;
         }
     }
@@ -140,10 +194,22 @@ unittest {
         assert( ch[ row, col ] == ch2[ row, col ]);
     }
     
+    auto ch3 = cholesky!( MatrixTriangle.Lower )( mat );
+    foreach( row; 0..3 ) foreach( col; 0..3 ) {
+        assert( ch3[ col, row ] == ch2[ row, col ]);
+    }
+    
     Matrix!double gen;
     gen[] = mat;
-    choleskyDestructive(gen);
+    choleskyDestructive( gen );
     foreach( row; 0..3 ) foreach( col; 0..3 ) {
         assert( ch[ row, col ] == gen[ row, col ]);
+    }
+    
+    Matrix!double gen2;
+    gen2[] = mat;
+    choleskyDestructive!( MatrixTriangle.Lower )( gen2 );
+    foreach( row; 0..3 ) foreach( col; 0..3 ) {
+        assert( gen2[ col, row ] == gen[ row, col ]);
     }
 }

--- a/scid/linalg.d
+++ b/scid/linalg.d
@@ -99,7 +99,7 @@ if( isMatrix!M && isGeneralMatrixStorage!( M.Storage, M.ElementType ) ) {
 
     int info;    
     lapack.potrf!( 'U' )
-        ( mat.length, mat.data, mat.rows, info );
+        ( mat.length, mat.data, mat.leading, info );
         
     // TODO:  Establish a consistent standard for error handling.
     // For now, just return a matrix of NaNs.
@@ -116,7 +116,6 @@ if( isMatrix!M && isGeneralMatrixStorage!( M.Storage, M.ElementType ) ) {
 }
     
 unittest {
-    import std.stdio;
     import std.math;
     
     // Easy way to get a positive definite matrix to test with:

--- a/scid/storage/symmetric.d
+++ b/scid/storage/symmetric.d
@@ -47,6 +47,8 @@ struct SymmetricArrayAdapter( ContainerRef_, MatrixTriangle tri_, StorageOrder s
 		enum storageType  = MatrixStorageType.Hermitian;
 	else
 		enum storageType  = MatrixStorageType.Symmetric;
+		
+	enum isResizable = is( typeof( Storage.init.resize(0,0) ) );
 	
 	this( A ... )( size_t newSize, A arrayArgs ) {
 		size_  = newSize;
@@ -108,18 +110,20 @@ struct SymmetricArrayAdapter( ContainerRef_, MatrixTriangle tri_, StorageOrder s
 		size_  = other.size_;
 	}
 	
-	void resize( A ... )( size_t newRows, size_t newCols, A arrayArgs )
-	in {
-		checkSquareDims_!"symmetric"( newRows, newCols );
-	} body {
-		size_t arrlen = packedArrayLength(newRows);
-		
-		if( !isInitd_ )
-			containerRef_ = ContainerRef( arrlen, arrayArgs );
-		else
-			containerRef_.resize( arrlen, arrayArgs );
-		
-		size_ = newRows;
+	static if( is( typeof( containerRef_.resize( 0, 0 ) ) ) ) {
+        void resize( A ... )( size_t newRows, size_t newCols, A arrayArgs )
+        in {
+            checkSquareDims_!"symmetric"( newRows, newCols );
+        } body {
+            size_t arrlen = packedArrayLength(newRows);
+            
+            if( !isInitd_ )
+                containerRef_ = ContainerRef( arrlen, arrayArgs );
+            else
+                containerRef_.resize( arrlen, arrayArgs );
+            
+            size_ = newRows;
+        }
 	}
 	
 	ref typeof( this ) opAssign( typeof(this) rhs ) {

--- a/scid/storage/triangular.d
+++ b/scid/storage/triangular.d
@@ -99,18 +99,20 @@ struct TriangularArrayAdapter( ContainerRef_, MatrixTriangle tri_, StorageOrder 
 		size_  = other.size_;
 	}
 	
-	void resize( A ... )( size_t newRows, size_t newCols, A arrayArgs )
-	in {
-		checkSquareDims_!"triangular"( newRows, newCols );
-	} body {
-		size_t arrlen = packedArrayLength(newRows);
-		
-		if( !isInitd_ )
-			containerRef_ = ContainerRef( arrlen, arrayArgs );
-		else
-			containerRef_.resize( arrlen, arrayArgs );
-		
-		size_ = newRows;
+	static if( is( typeof( containerRef_.resize( 0, 0 ) ) ) ) {
+        void resize( A ... )( size_t newRows, size_t newCols, A arrayArgs )
+        in {
+            checkSquareDims_!"triangular"( newRows, newCols );
+        } body {
+            size_t arrlen = packedArrayLength(newRows);
+            
+            if( !isInitd_ )
+                containerRef_ = ContainerRef( arrlen, arrayArgs );
+            else
+                containerRef_.resize( arrlen, arrayArgs );
+            
+            size_ = newRows;
+        }
 	}
 	
 	ref typeof( this ) opAssign( typeof(this) rhs ) {


### PR DESCRIPTION
Add cholesky stuff.  Created a module called scid.linalg for "extra" linear algebra functions that don't belong with expression templates.  Also, fix a bug where symmetric and triangular storage didn't work with external arrays.

Please let me know what you think of a few conventions I've chosen.  If you have a better idea for them, I could change them:
1.  Error handling:  Return a matrix of NaNs if the matrix isn't positive definite or whatever.
2.  The in-place version that destroys the input matrix and uses it for the result and/or scratch space is called someFunctionDestructive.  BTW, we should eventually add solveDestructive, too.  This was in Lars's old SciD.
